### PR TITLE
Allow for easy flipping of variable axes in the event of unexpected graph orientation

### DIFF
--- a/R/geom_parttree.R
+++ b/R/geom_parttree.R
@@ -6,6 +6,9 @@
 #' @param data An \code{\link[rpart]{rpart.object}}, or an object of compatible
 #'   type (e.g. a decision tree constructed via the `parsnip` or `mlr3`
 #'   front-ends).
+#' @param flipaxes Logical. The function will automatically set the yaxis
+#'   variable as the first split variable in the tree provided unless
+#'   the user specifies `TRUE`.
 #' @import ggplot2
 #' @inheritParams ggplot2::layer
 #' @inheritParams ggplot2::geom_point
@@ -87,8 +90,8 @@ geom_parttree <-
   function(mapping = NULL, data = NULL,
            stat = "identity", position = "identity",
            linejoin = "mitre", na.rm = FALSE, show.legend = NA,
-           inherit.aes = TRUE, ...) {
-    pdata <- parttree(data)
+           inherit.aes = TRUE, flipaxes = FALSE, ...) {
+    pdata <- parttree(data, flipaxes = flipaxes)
     mapping_null = is.null(mapping)
     mapping$xmin = quote(xmin)
     mapping$xmax = quote(xmax)

--- a/R/parttree.R
+++ b/R/parttree.R
@@ -10,6 +10,9 @@
 #' @param keep_as_dt Logical. The function relies on `data.table` for internal
 #'   data manipulation. But it will coerce the final return object into a
 #'   regular data frame (default behaviour) unless the user specifies `TRUE`.
+#' @param flipaxes Logical. The function will automatically set the yaxis
+#'   variable as the first split variable in the tree provided unless
+#'   the user specifies `TRUE`.
 #' @details This function can be used with a regression or classification tree
 #'   containing one or (at most) two continuous predictors.
 #' @seealso \code{\link{geom_parttree()}}, \code{\link[rpart]{rpart}}.
@@ -22,7 +25,7 @@
 #' library(rpart)
 #' parttree(rpart(Species ~ Petal.Length + Petal.Width, data=iris))
 parttree =
-  function(tree, keep_as_dt = FALSE) {
+  function(tree, keep_as_dt = FALSE, flipaxes = FALSE) {
     if (!(inherits(tree, "rpart") || inherits(tree, "_rpart") ||
           inherits(tree, "LearnerClassifRpart") || inherits(tree, "LearnerRegrRpart"))) {
       stop("The parttree() function only accepts rpart objects.\n",
@@ -100,9 +103,16 @@ parttree =
                       keyby = .(node, var, side)]
 
     ## Get the coords data frame
+    if (flipaxes) {
+      var1 = 2
+      var2 = 1
+    } else {
+      var1 = 1
+      var2 = 2
+    }
     part_coords =
       part_dt[, `:=`(split = as.double(split))][
-        , `:=`(xvar = var == ..vars[1], yvar = var == ..vars[2])][
+        , `:=`(xvar = var == ..vars[var1], yvar = var == ..vars[var2])][
           , `:=`(xmin = ifelse(xvar, ifelse(grepl(">", side), split, NA), NA),
                  xmax = ifelse(xvar, ifelse(grepl("<", side), split, NA), NA),
                  ymin = ifelse(yvar, ifelse(grepl(">", side), split, NA), NA),

--- a/R/parttree.R
+++ b/R/parttree.R
@@ -103,16 +103,10 @@ parttree =
                       keyby = .(node, var, side)]
 
     ## Get the coords data frame
-    if (flipaxes) {
-      var1 = 2
-      var2 = 1
-    } else {
-      var1 = 1
-      var2 = 2
-    }
+    if (flipaxes) vars = rev(vars)
     part_coords =
       part_dt[, `:=`(split = as.double(split))][
-        , `:=`(xvar = var == ..vars[var1], yvar = var == ..vars[var2])][
+        , `:=`(xvar = var == ..vars[1], yvar = var == ..vars[2])][
           , `:=`(xmin = ifelse(xvar, ifelse(grepl(">", side), split, NA), NA),
                  xmax = ifelse(xvar, ifelse(grepl("<", side), split, NA), NA),
                  ymin = ifelse(yvar, ifelse(grepl(">", side), split, NA), NA),


### PR DESCRIPTION
Created a new argument in geom_parttree(), which passes to the parttree() call, that changes the order in which xvar and yvar variables are set in the data frame coerced from tree model. This is intended to make fixing the unexpected graph orientation issue easier on the end-user (the "Oops!" example in the README).

As of right now, order is determined by `vars`, which is in turn determined by the line `unique(as.character(tree$frame[tree$frame$var != "<leaf>", ]$var))`. This has the effect of setting the xvar and yvar for graphing based on the first split in the tree, which may not always be desired and may change unpredictably (e.g. based on training/test splits when making the rpart model). Argument is a blunt way of flipping the axes by just reversing which element of `vars` is set to xvar and yvar later - probably not optimal or best practices, but a suggestion to start with!